### PR TITLE
ConvexHull: add parameter to explicitly set dimensionality of the data/hull

### DIFF
--- a/src/surface/ConvexHull.cpp
+++ b/src/surface/ConvexHull.cpp
@@ -36,7 +36,10 @@ namespace ecto {
 
     struct ConvexHull
     {
-      static void declare_params(tendrils& params) { }
+      static void declare_params(tendrils& params)
+      {
+        params.declare(&ConvexHull::dimensionality_, "dimensionality", "Dimensionality of the data (valid: 2 and 3)", 3);
+      }
 
       static void declare_io(const tendrils& params, tendrils& inputs, tendrils& outputs)
       {
@@ -47,22 +50,23 @@ namespace ecto {
       {
         output_ = outputs["output"];
       }
-      
+
       template <typename Point>
-      int process(const tendrils& inputs, const tendrils& outputs, 
+      int process(const tendrils& inputs, const tendrils& outputs,
                   boost::shared_ptr<const ::pcl::PointCloud<Point> >& input)
       {
         ::pcl::ConvexHull<Point> filter;
         typename ::pcl::PointCloud<Point>::Ptr cloud(new typename ::pcl::PointCloud<Point>);
 
         filter.setInputCloud(input);
-        filter.setDimension(3);
+        filter.setDimension(*dimensionality_);
         filter.reconstruct(*cloud);
 
         *output_ = xyz_cloud_variant_t(cloud);
         return ecto::OK;
       }
 
+      spore<int> dimensionality_;
       spore<PointCloud> output_;
     };
 


### PR DESCRIPTION
I had qhull 2012 via pcl 1.7.2 complaining over here that the input is, 
indeed, _not_ three dimensional when computing the hull of a detected table. 
Turned out pcl is always told to reconstruct a 3d-hull.
