### PR TITLE
pcl_cell: don't ignore the return value of the wrapped cell

### DIFF
--- a/include/ecto_pcl/pcl_cell.hpp
+++ b/include/ecto_pcl/pcl_cell.hpp
@@ -51,9 +51,9 @@ namespace ecto{
         input_ = inputs["input"];
         CellType::configure(params, inputs, outputs);
       }
-    
+
       /* dispatch to handle process */
-      struct filter_dispatch : boost::static_visitor<void>
+      struct filter_dispatch : boost::static_visitor<int>
       {
         CellType& ft;
         const tendrils& inputs;
@@ -62,17 +62,16 @@ namespace ecto{
         filter_dispatch(CellType& ft_, const tendrils& input_, const tendrils& output_) : ft(ft_), inputs(input_), outputs(output_) { }
 
         template <typename Point>
-        void operator()(boost::shared_ptr<const ::pcl::PointCloud<Point> >& cloud) const
-        {   
-            ft.process(inputs, outputs, cloud);
+        int operator()(boost::shared_ptr<const ::pcl::PointCloud<Point> >& cloud) const
+        {
+            return ft.process(inputs, outputs, cloud);
         }
       };
 
       int process(const tendrils& inputs, const tendrils& outputs)
       {
         xyz_cloud_variant_t cloud = input_->make_variant();
-        boost::apply_visitor(filter_dispatch(*this, inputs, outputs), cloud);
-        return 0;
+        return boost::apply_visitor(filter_dispatch(*this, inputs, outputs), cloud);
       }
 
       ecto::spore<PointCloud> input_;


### PR DESCRIPTION
This makes sure ecto actually stops processing in case one of the cells 
produces an error and returns something else than ecto::OK.

At the moment cells wrapped by PclCell always return 0 (ecto::OK)
and cells depending on a cell whose process method failed are still called.
